### PR TITLE
feat: X32 Solo and Clear Solo (Issue #47)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -775,7 +775,8 @@ export function GetActionsList(
 				},
 			],
 			callback: (action): void => {
-				const cmd = `/-stat/solosw/${action.options.solo}`
+				const ch = `${getOptNumber(action, 'solo')+1}`.padStart(2,"0")
+				const cmd = `/-stat/solosw/${ch}`
 				const onState = getResolveOnOffMute(action, cmd, true, 'on')
 
 				sendOsc(cmd, {
@@ -785,7 +786,8 @@ export function GetActionsList(
 			},
 			subscribe: (evt): void => {
 				if (evt.options.on === MUTE_TOGGLE) {
-					ensureLoaded(`/-stat/solosw/${evt.options.solo}`)
+					const ch = `${getOptNumber(evt, 'solo')+1}`.padStart(2,"0")
+					ensureLoaded(`/-stat/solosw/${ch}`)
 				}
 			},
 		},

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -574,15 +574,23 @@ export function GetFeedbacksList(
 			type: 'boolean',
 			label: 'Change from clear solo state',
 			description: 'If atleast one solo is selected the clear solo button is on and will change style of the bank',
-			options:[],
+			options:[
+				{
+					id: 'state',
+					type: 'checkbox',
+					label: 'On',
+					default: true,
+				},
+			],
 			style: {
 				bgcolor: self.rgb(255, 127, 0),
 				color: self.rgb(0, 0, 0),
 			},
-			callback: (): boolean => {
+			callback: (evt: CompanionFeedbackEvent): boolean => {
 				const path = `/-stat/solo`
 				const data = path ? state.get(path) : undefined
-				return getDataNumber(data, 0) !== 0
+				const isOn = getDataNumber(data, 0) !== 0
+				return isOn === !!evt.options.state
 			},
 			subscribe: (evt: CompanionFeedbackEvent): void => {
 				const path = `/-stat/solo`


### PR DESCRIPTION
Added actions for Soloing channels and triggering the "Clear Solo" button (Requested in issue #47)
Also added Feedbacks for soloed channels and clear solo button.
Also added Feedback for selected channel as it was missing