### PR TITLE
feat: add _float suffix variables for fader values (v4.0.0-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ While developing the module, by using `yarn dev` the compiler will be run in wat
 
 ## Changes
 
+### v4.0.0-1
+
+- Add `_float` variables for all fader values (e.g. `$(x32:fader_ch_01_float)`, `$(x32:fader_ch_18_to_bus_07_float)`)
+- Float values are in normalized range 0.0–1.0 as received from the X32 over OSC
+
 ### v4.0
 
 - Update to 2.0 module api

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "behringer-x32",
-	"version": "4.0.0",
+	"version": "4.0.0-1",
 	"main": "dist/main.js",
 	"type": "module",
 	"scripts": {

--- a/src/variables/main.ts
+++ b/src/variables/main.ts
@@ -186,6 +186,14 @@ for (const target of allSources) {
 				return isNaN(faderNum) ? undefined : floatToDB(faderNum)
 			},
 		}
+		VariableDefinitions[`fader_${target.variablesPrefix}_float`] = {
+			name: `Fader (float): ${target.defaultName}`,
+			oscPath: target.level.path,
+			getValue: (args) => {
+				const faderNum = args && args[0]?.type === 'f' ? args[0].value : NaN
+				return isNaN(faderNum) ? undefined : faderNum
+			},
+		}
 	}
 }
 
@@ -201,6 +209,16 @@ for (const source of sendToBusSources) {
 				const faderNum = args && args[0]?.type === 'f' ? args[0].value : NaN
 				return isNaN(faderNum) ? undefined : floatToDB(faderNum)
 			},
+		}
+		if (dest.sendToSink.level) {
+			VariableDefinitions[`fader_${source.variablesPrefix}_to_${dest.variablesPrefix}_float`] = {
+				name: `Fader (float): ${source.defaultName} to ${dest.defaultName}`,
+				oscPath: `${source.sendTo.path}/${dest.sendToSink.level}`,
+				getValue: (args) => {
+					const faderNum = args && args[0]?.type === 'f' ? args[0].value : NaN
+					return isNaN(faderNum) ? undefined : faderNum
+				},
+			}
 		}
 	}
 }
@@ -218,6 +236,18 @@ for (const source of busSources) {
 				const faderNum = args && args[0]?.type === 'f' ? args[0].value : NaN
 				return isNaN(faderNum) ? undefined : floatToDB(faderNum)
 			},
+		}
+		if (dest.sendToSink.level) {
+			const varNameFloat =
+				`fader_${source.variablesPrefix}_to_${dest.variablesPrefix.replace('mtx', 'matrix')}_float` as const
+			VariableDefinitions[varNameFloat] = {
+				name: `Fader (float): ${source.defaultName} to ${dest.defaultName}`,
+				oscPath: `${source.sendTo.path}/${dest.sendToSink.level}`,
+				getValue: (args) => {
+					const faderNum = args && args[0]?.type === 'f' ? args[0].value : NaN
+					return isNaN(faderNum) ? undefined : faderNum
+				},
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary                                                                                                                                                           
   
  Fader variables like $(x32:fader_ch_18_to_bus_07) currently return values in dB. This PR adds a _float variant for every fader variable, exposing the raw         
  normalized float value (0.0–1.0) directly from the X32 OSC protocol.                                                                                            
                                                                                                                                                                    
 ## New variables:                                                                                                                                                    
  - $(x32:fader_ch_01_float) — direct fader (channels, buses, DCA, aux, …)
  - $(x32:fader_ch_18_to_bus_07_float) — channel send to bus                                                                                                        
  - $(x32:fader_bus_07_to_matrix_01_float) — bus send to matrix                                                                                                   
                                                                                                                                                                    
  ## Float value scale:                                                                                                                                              
  - 0.0 = −90 dB (muted)                                                                                                                                            
  - 0.5 ≈ −10 dB                                                                                                                                                    
  - 1.0 = +10 dB (maximum)                                                                                                                                          
                                                                                                                                                                    
  
 Existing dB variables are unchanged!                                                                                                                            
                                                                                                                                                                    
 ## Use case                                                                                                                                                          
                                                                                                                                                                    
  Useful for calculations, interpolation, or automations that work better in normalized float space — e.g. driving external systems, crossfades, or custom math     
  expressions in Companion.