### PR TITLE
feat: add Fader Control (Encoder) action and Fader State Display feedback

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -24,7 +24,47 @@ We support the following actions:
 | Load Console Snippet                                           | Loads the given snippet from the consoles internal snippet list 0-99                                               |
 | Tape Operation                                                 | Stop,Play,PlayPause,Record,RecordPause,Fast Forward,Rewind of the tape Deck                                        |
 | Talkback Talk                                                  | Talkback talk on/off                                                                                               |
+| Fader Control (Encoder)                                        | Adjusts a fader by a fixed step per encoder detent, designed for Stream Deck + and similar rotary controllers      |
+| Fader State Display (feedback)                                 | Shows live fader level, mute state, and scribble-strip name on a button, updating in real time from the console    |
 
 for additional actions please raise a feature request at [github](https://github.com/bitfocus/companion-module-behringer-x32)
 
 If setting a fade duration, running another action for that value will cancel the first, and run the new one from the current level. If you wish to cancel a fade, run an 'Adjust fader level' with an offset of 0.
+
+## Encoder Actions (Stream Deck + and similar)
+
+### Fader Control (Encoder)
+
+Designed for rotary encoders such as the Stream Deck +. Each detent moves a fader by a fixed step with no fade or easing — changes are sent to the console immediately for low-latency response.
+
+**Setup:** Assign two instances of this action to the same encoder button — one with Direction = **Up (CW)** for clockwise rotation and one with Direction = **Down (CCW)** for counter-clockwise.
+
+**Supported targets:** Channels 1–32, Aux Inputs 1–8, FX Returns 1-4, Buses 1–16, Matrix 1–6, Main L/R, Main M/C, DCAs 1–8.
+
+| Option       | Description                             |
+| ------------ | --------------------------------------- |
+| Fader Target | The fader to control                    |
+| Step Size    | How much to move per detent             |
+| Direction    | Up (CW rotation) or Down (CCW rotation) |
+
+## Feedbacks
+
+### Fader State Display
+
+An **advanced** feedback that renders live console state on a button. Unlike boolean feedbacks (which change the button style when a condition is true), this feedback actively composes text lines and sets the background colour on every update.
+
+Each enabled field is shown as a separate line on the button, from top to bottom.
+
+**Supported targets:** same as the encoder action — all fader types.
+
+| Option                     | Description                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------------ |
+| Fader Target               | The fader to monitor                                                                 |
+| Show channel number / type | Top line: channel identifier, e.g. `Channel 1`, `MixBus 3`, `DCA 2`                  |
+| Show scribble strip name   | The name set on the console's scribble strip. Hidden if no name is set.              |
+| Show fader level in dB     | Current level formatted as `-12.5 dB`, `0.0 dB`, or `-∞` when the fader is fully off |
+| Show mute state            | `MUTED` when the channel is muted, `LIVE` when active                                |
+| Muted background color     | Button background colour when muted (default: red)                                   |
+| Live background color      | Button background colour when active (default: black)                                |
+
+The feedback subscribes to the fader level, mute state, and scribble strip name OSC paths simultaneously and updates in real time whenever any of them change on the console. No polling is required.

--- a/src/actions/encoder.ts
+++ b/src/actions/encoder.ts
@@ -1,0 +1,134 @@
+import type { CompanionActionDefinitions } from '@companion-module/base'
+import type { ActionsProps } from './main.js'
+import { actionSubscriptionWrapper } from './util.js'
+import { convertChoices, GetLevelsChoiceConfigs } from '../choices.js'
+import { parseRefToPaths } from '../paths.js'
+import { dbToFloat, floatToDB } from '../util.js'
+
+export type EncoderActionsSchema = {
+	fader_encoder: {
+		options: {
+			target: string
+			step: string
+			direction: string
+		}
+	}
+}
+
+const ENCODER_STEP_CHOICES = [
+	{ id: '5db', label: '5 dB – large jump, good for rough level setting' },
+	{ id: '3db', label: '3 dB – standard increment, noticeable but musical' },
+	{ id: '1db', label: '1 dB – fine control, good for subtle riding' },
+	{ id: '0.5db', label: '0.5 dB – very fine, precise adjustments' },
+	{ id: 'fine', label: 'Fine (0.01 fader unit) – slow, precise travel, ~0.5–1 dB near unity' },
+	{ id: 'medium', label: 'Medium (0.025 fader unit) – balanced feel, ~1–2 dB near unity' },
+	{ id: 'coarse', label: 'Coarse (0.05 fader unit) – fast travel, ~2–4 dB near unity' },
+]
+
+const ENCODER_DIRECTION_CHOICES = [
+	{ id: 'up', label: 'Up (CW rotation)' },
+	{ id: 'down', label: 'Down (CCW rotation)' },
+]
+
+/**
+ * Apply one encoder detent to a fader float value (0.0–1.0).
+ *
+ * dB steps operate in dB space using the X32's piecewise-linear fader curve
+ * (floatToDB / dbToFloat). Float steps move the raw position value directly,
+ * producing consistent "physical travel" feel across the entire fader range
+ * at the cost of varying dB increments (larger near the bottom, smaller near unity).
+ */
+function applyEncoderStep(currentFloat: number, step: string, direction: string): number {
+	const sign = direction === 'up' ? 1 : -1
+
+	if (step === 'fine') {
+		return Math.max(0, Math.min(1, currentFloat + sign * 0.01))
+	}
+
+	if (step === 'medium') {
+		return Math.max(0, Math.min(1, currentFloat + sign * 0.025))
+	}
+
+	if (step === 'coarse') {
+		return Math.max(0, Math.min(1, currentFloat + sign * 0.05))
+	}
+
+	// dB-based step: work in dB space then convert back to float
+	const dbDelta = sign * stepToDb(step)
+	const currentDb = floatToDB(currentFloat)
+	// Treat -∞ (fader at 0.0) as -90 dB so moving up from silence works correctly
+	const fromDb = Number.isFinite(currentDb) ? currentDb : -90
+	return Math.max(0, Math.min(1, dbToFloat(fromDb + dbDelta)))
+}
+
+function stepToDb(step: string): number {
+	switch (step) {
+		case '5db':
+			return 5
+		case '3db':
+			return 3
+		case '1db':
+			return 1
+		case '0.5db':
+			return 0.5
+		default:
+			// A step choice was added to ENCODER_STEP_CHOICES without a matching case here.
+			throw new Error(`Unknown dB step: ${step}`)
+	}
+}
+
+export function getEncoderActions(props: ActionsProps): CompanionActionDefinitions<EncoderActionsSchema> {
+	const levelsChoices = GetLevelsChoiceConfigs(props.state)
+
+	return {
+		fader_encoder: {
+			name: 'Fader Control (Encoder)',
+			description:
+				'Adjust a fader by a fixed step per encoder detent. ' +
+				'Assign two instances to one encoder: Direction = Up on CW, Direction = Down on CCW.',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Fader Target',
+					id: 'target',
+					...convertChoices(levelsChoices.channels),
+					allowInvalidValues: true,
+				},
+				{
+					type: 'dropdown',
+					label: 'Step Size',
+					id: 'step',
+					choices: ENCODER_STEP_CHOICES,
+					default: '1db',
+					disableAutoExpression: true,
+				},
+				{
+					type: 'dropdown',
+					label: 'Direction',
+					id: 'direction',
+					choices: ENCODER_DIRECTION_CHOICES,
+					default: 'up',
+					disableAutoExpression: true,
+				},
+			],
+			...actionSubscriptionWrapper(props, {
+				getPath: (options) => {
+					const refPaths = parseRefToPaths(options.target, levelsChoices.channelsParseOptions)
+					return refPaths?.level?.path ?? null
+				},
+				execute: (action, cachedData, _path) => {
+					// Fall back to unity (0 dB) if the fader value hasn't been received yet.
+					// actionSubscriptionWrapper calls ensureLoaded on subscribe, so this only
+					// affects the first press before the console has responded.
+					const currentFloat = cachedData?.[0]?.type === 'f' ? cachedData[0].value : 0.75
+					const newFloat = applyEncoderStep(currentFloat, String(action.options.step), String(action.options.direction))
+					return [{ type: 'f' as const, value: newFloat }]
+				},
+				shouldSubscribe: true,
+				// Only re-run subscribe/unsubscribe when the target changes, not on every
+				// step/direction edit — those options don't affect which OSC path is cached.
+				optionsToMonitorForSubscribe: ['target'],
+			}),
+		},
+	}
+}

--- a/src/actions/main.ts
+++ b/src/actions/main.ts
@@ -25,6 +25,7 @@ import { getUndoActions, UndoActionsSchema } from './undo.js'
 import { FaderBankActionsSchema, getFaderBankActions } from './fader-bank.js'
 import { getHeadAmpActions, HeadAmpActionsSchema } from './headamp.js'
 import { getMiscActions, MiscActionsSchema } from './misc.js'
+import { getEncoderActions, EncoderActionsSchema } from './encoder.js'
 
 export type ActionsSchema = XLiveActionsSchema &
 	MarkerActionsSchema &
@@ -49,7 +50,8 @@ export type ActionsSchema = XLiveActionsSchema &
 	UndoActionsSchema &
 	FaderBankActionsSchema &
 	HeadAmpActionsSchema &
-	MiscActionsSchema
+	MiscActionsSchema &
+	EncoderActionsSchema
 
 export interface ActionsProps {
 	readonly transitions: X32Transitions
@@ -84,5 +86,6 @@ export function GetActionsList(props: ActionsProps): CompanionActionDefinitions<
 		...getFaderBankActions(props),
 		...getHeadAmpActions(props),
 		...getMiscActions(props),
+		...getEncoderActions(props),
 	}
 }

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -32,7 +32,9 @@ import osc from 'osc'
 import { NumberComparitorPicker } from './input.js'
 import type { SetRequired } from 'type-fest'
 import {
+	CompanionAdvancedFeedbackDefinition,
 	CompanionBooleanFeedbackDefinition,
+	CompanionFeedbackAdvancedEvent,
 	CompanionFeedbackDefinitions,
 	CompanionFeedbackInfo,
 	CompanionOptionValues,
@@ -396,6 +398,18 @@ export type FeedbacksSchema = {
 		type: 'boolean'
 		options: Record<string, never>
 	}
+	fader_state_display: {
+		type: 'advanced'
+		options: {
+			target: string
+			show_channel_num: boolean
+			show_name: boolean
+			show_fader_level: boolean
+			show_mute_state: boolean
+			muted_bgcolor: number
+			live_bgcolor: number
+		}
+	}
 }
 
 function getDataNumber(data: osc.MetaArgument[] | undefined, index: number): number | undefined {
@@ -514,6 +528,12 @@ export function GetFeedbacksList(
 			},
 		}
 	}
+
+	// Tracks which OSC paths each fader_state_display feedback instance is
+	// subscribed to, keyed by feedback ID. Used for cleanup on every callback
+	// invocation and on unsubscribe — avoids relying on evt.previousOptions,
+	// which can be stale or absent after a reconnect.
+	const faderStateSubscribedPaths = new Map<string, string[]>()
 
 	const feedbacks: CompanionFeedbackDefinitions<FeedbacksSchema> = {
 		record: {
@@ -2566,6 +2586,151 @@ export function GetFeedbacksList(
 				},
 			}),
 		},
+		fader_state_display: {
+			type: 'advanced',
+			name: 'Fader State Display',
+			description: 'Show live fader level, mute state, and name on a button. Updates in real time from OSC.',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Fader Target',
+					id: 'target',
+					...convertChoices(levelsChoices.channels),
+					allowInvalidValues: true,
+				},
+				{
+					type: 'checkbox',
+					label: 'Show channel number / type',
+					id: 'show_channel_num',
+					default: false,
+				},
+				{
+					type: 'checkbox',
+					label: 'Show scribble strip name',
+					id: 'show_name',
+					default: true,
+				},
+				{
+					type: 'checkbox',
+					label: 'Show fader level in dB',
+					id: 'show_fader_level',
+					default: true,
+				},
+				{
+					type: 'checkbox',
+					label: 'Show mute state (MUTED / LIVE)',
+					id: 'show_mute_state',
+					default: false,
+				},
+				{
+					type: 'colorpicker',
+					label: 'Muted background color',
+					id: 'muted_bgcolor',
+					default: 0xff0000,
+				},
+				{
+					type: 'colorpicker',
+					label: 'Live background color',
+					id: 'live_bgcolor',
+					default: 0x000000,
+				},
+			],
+			callback: (evt: CompanionFeedbackAdvancedEvent<FeedbacksSchema['fader_state_display']['options']>) => {
+				const refPaths = parseRefToPaths(evt.options.target, levelsChoices.channelsParseOptions)
+
+				// Unsubscribe from the paths this instance was previously registered on.
+				// Using a local Map rather than evt.previousOptions avoids the case where
+				// previousOptions is stale or absent after a reconnect.
+				const prevPaths = faderStateSubscribedPaths.get(evt.id) ?? []
+				for (const p of prevPaths) subs.unsubscribe(p, evt.id)
+
+				if (!refPaths) {
+					faderStateSubscribedPaths.delete(evt.id)
+					return {}
+				}
+
+				const levelPath = refPaths.level?.path ?? null
+				const mutePath = refPaths.muteOrOn?.path ?? null
+				const namePath = refPaths.namePath ?? null
+
+				// Register subscriptions and record the active paths for this instance.
+				// subs.subscribe is idempotent (Map.set), so calling it on every invocation
+				// is safe and ensures subscriptions are re-established after a reconnect.
+				const activePaths: string[] = []
+				if (levelPath) {
+					subscribeFeedback(ensureLoaded, subs, levelPath, evt)
+					activePaths.push(levelPath)
+				}
+				if (mutePath) {
+					subscribeFeedback(ensureLoaded, subs, mutePath, evt)
+					activePaths.push(mutePath)
+				}
+				if (namePath) {
+					subscribeFeedback(ensureLoaded, subs, namePath, evt)
+					activePaths.push(namePath)
+				}
+				faderStateSubscribedPaths.set(evt.id, activePaths)
+
+				// Read cached OSC values written by the message handler in main.ts
+				const faderData = levelPath ? state.get(levelPath) : undefined
+				const muteData = mutePath ? state.get(mutePath) : undefined
+				const nameData = namePath ? state.get(namePath) : undefined
+
+				// muteOrOn.isOn: true means the path represents an "on" signal (1=live, 0=muted),
+				// which is how channels, buses, and DCAs all work on the X32.
+				let isMuted = false
+				if (refPaths.muteOrOn && muteData) {
+					const val = muteData[0]?.type === 'i' ? muteData[0].value : undefined
+					isMuted = refPaths.muteOrOn.isOn ? val === 0 : val === 1
+				}
+
+				const lines: string[] = []
+
+				if (evt.options.show_channel_num) {
+					lines.push(refPaths.defaultName)
+				}
+
+				if (evt.options.show_name) {
+					const name = nameData?.[0]?.type === 's' ? nameData[0].value.trim() : ''
+					if (name) lines.push(name)
+				}
+
+				if (evt.options.show_fader_level) {
+					const fFloat = faderData?.[0]?.type === 'f' ? faderData[0].value : undefined
+					if (fFloat !== undefined) {
+						if (fFloat === 0) {
+							// Fader fully off. floatToDB(0) returns -90 due to its piecewise
+							// formula, but X32 convention is -∞ at this position.
+							lines.push('-\u221e dB')
+						} else {
+							const db = floatToDB(fFloat)
+							const sign = db >= 0 ? '+' : '-'
+							lines.push(`${sign}${Math.abs(db).toFixed(1)} dB`)
+						}
+					}
+				}
+
+				if (evt.options.show_mute_state) {
+					lines.push(isMuted ? 'MUTED' : 'LIVE')
+				}
+
+				// Fix the font size based on line count so Companion's auto-sizer
+				// never fires. Auto-sizing changes the font when text pixel width
+				// varies (different digit counts, ∞ glyph, ± sign widths), causing
+				// the button to visually "jump" on every dB update.
+				const fixedSizes = ['24', '18', '14', '7'] as const
+				return {
+					text: lines.join('\n'),
+					bgcolor: isMuted ? Number(evt.options.muted_bgcolor) : Number(evt.options.live_bgcolor),
+					size: fixedSizes[Math.min(lines.length - 1, 3)],
+				}
+			},
+			unsubscribe: (evt: CompanionFeedbackInfo<FeedbacksSchema['fader_state_display']['options']>) => {
+				const paths = faderStateSubscribedPaths.get(evt.id) ?? []
+				for (const p of paths) subs.unsubscribe(p, evt.id)
+				faderStateSubscribedPaths.delete(evt.id)
+			},
+		} satisfies CompanionAdvancedFeedbackDefinition<FeedbacksSchema['fader_state_display']['options']>,
 	}
 
 	return feedbacks

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -453,7 +453,9 @@ export function getMatrixPaths(matrixNumber: number): SourcePaths | null {
 export function getDcaPaths(dcaNumber: number): SourcePaths | null {
 	if (dcaNumber < 1 || dcaNumber > 8) return null
 
-	const basePath = `/dca/${String(dcaNumber).padStart(2, '0')}`
+	// X32 DCA paths use single-digit numbers (/dca/1 through /dca/8), unlike
+	// channels and buses which use zero-padded two-digit numbers (/ch/01, /bus/01).
+	const basePath = `/dca/${dcaNumber}`
 
 	return {
 		defaultName: `DCA ${dcaNumber}`,


### PR DESCRIPTION
- Adds a fader_encoder action for rotary encoders (Stream Deck +): moves any fader by a fixed step per detent, no easing. Supports channels 1–32, aux 1–8, FX returns 1–8, buses 1–16, matrix 1–6, main L/R, main M/C, DCAs 1–8. Seven step sizes (four dB-space, three float-space). Assign two instances to one encoder — Up on CW, Down on CCW.

- Adds a fader_state_display advanced feedback: renders live dB level, mute state, scribble-strip name, and channel identifier on a button. Subscribes to all three OSC paths simultaneously, updates in real time, no polling.

- Fixes a pre-existing bug in getDcaPaths where DCA paths were zero-padded (/dca/01) instead of single-digit (/dca/1), breaking all DCA fader and feedback functionality.